### PR TITLE
allow configuration of container name and exposed port via cli run command

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,7 @@ jobs:
     permissions:
       contents: read
       checks: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository

--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ source-files:
 # (Required - can be empty) A list of dependencies required to run the classes.
 dependencies:
   - org.apache.commons:commons-lang3:3.18.0
+
+# (Optional) Used to provide configs for the WireMock Docker image spin up via CLI `run` command.
+jar-run-config:
+   # (Optional) The name of the Docker container that will be created. Defaults to `wiremock-docker-easy-extensions`.
+   docker-container-name: wiremock-docker-easy-extensions
+   # (Optional) The port that Docker will expose for WireMock. Defaults to `8080`.
+   docker-port: 8080
 ```
 
 ### Extension Language and Compatibility

--- a/examples/wiremock-docker-easy-extensions-config.yaml
+++ b/examples/wiremock-docker-easy-extensions-config.yaml
@@ -7,3 +7,7 @@ source-files:
 
 dependencies:
   - org.apache.commons:commons-lang3:3.18.0
+
+jar-run-config:
+  docker-port: 8080
+  docker-container-name: wiremock-docker-easy-extensions

--- a/src/main/kotlin/app/Application.kt
+++ b/src/main/kotlin/app/Application.kt
@@ -43,6 +43,7 @@ class Application {
                 if (success) {
                     val projectRoot = File(".").canonicalFile
                     dockerRunner.runWiremockContainer(
+                        config.jarRunConfig,
                         WireMockConfigForRunCommand(config.sourceFilesLocation),
                         OutputConfig,
                         projectRoot,

--- a/src/main/kotlin/config/Config.kt
+++ b/src/main/kotlin/config/Config.kt
@@ -8,6 +8,13 @@ data class Config(
     @SerialName("source-files-location") val sourceFilesLocation: String,
     @SerialName("source-files") val sourceFiles: List<String>,
     val dependencies: List<String>?,
+    @SerialName("jar-run-config") val jarRunConfig: JarRunConfig = JarRunConfig(),
+)
+
+@Serializable
+data class JarRunConfig(
+    @SerialName("docker-container-name") val dockerContainerName: String = "wiremock-docker-easy-extensions",
+    @SerialName("docker-port")val dockerPort: Int = 8080,
 )
 
 @ConsistentCopyVisibility

--- a/src/main/kotlin/docker/DockerRunner.kt
+++ b/src/main/kotlin/docker/DockerRunner.kt
@@ -1,5 +1,6 @@
 package docker
 
+import config.JarRunConfig
 import config.OutputConfig
 import config.WireMockConfigForRunCommand
 import java.io.File
@@ -9,18 +10,18 @@ class DockerRunner {
      * Runs a WireMock container with the generated extensions.
      */
     fun runWiremockContainer(
-        docker: WireMockConfigForRunCommand,
-        output: OutputConfig,
+        jarRunConfig: JarRunConfig,
+        wireMockConfigForRunCommand: WireMockConfigForRunCommand,
+        outputConfig: OutputConfig,
         projectRoot: File,
     ) {
-        val containerName = "wiremock-docker-easy-extensions"
-        println("\n🚀 Starting WireMock container '$containerName'...")
+        println("\n🚀 Starting WireMock container '$jarRunConfig.dockerContainerName'...")
 
-        val dockerMappingsPath = projectRoot.resolve(docker.mappingsDir).absolutePath
-        val dockerFilesPath = projectRoot.resolve(docker.filesDir).absolutePath
+        val dockerMappingsPath = projectRoot.resolve(wireMockConfigForRunCommand.mappingsDir).absolutePath
+        val dockerFilesPath = projectRoot.resolve(wireMockConfigForRunCommand.filesDir).absolutePath
         val extensionsJarPath =
             projectRoot
-                .resolve(output.DIR)
+                .resolve(outputConfig.DIR)
                 .absolutePath
 
         val command =
@@ -29,16 +30,16 @@ class DockerRunner {
                 "run",
                 "--rm",
                 "--name",
-                containerName,
+                jarRunConfig.dockerContainerName,
                 "-p",
-                "8080:8080",
+                "${jarRunConfig.dockerPort}:8080",
                 "-v",
                 "$dockerMappingsPath:/home/wiremock/mappings",
                 "-v",
                 "$dockerFilesPath:/home/wiremock/__files",
                 "-v",
                 "$extensionsJarPath:/var/wiremock/extensions/",
-                "wiremock/wiremock:latest",
+                "wiremock/wiremock:3.13.1",
                 "--verbose",
             )
 
@@ -46,7 +47,7 @@ class DockerRunner {
             Thread {
                 println("\n🛑 Stopping WireMock container...")
                 try {
-                    ProcessBuilder("docker", "stop", containerName).start().waitFor()
+                    ProcessBuilder("docker", "stop", jarRunConfig.dockerContainerName).start().waitFor()
                 } catch (e: Exception) {
                     System.err.println("Failed to stop container: ${e.message}")
                 }

--- a/src/test/kotlin/config/ConfigLoaderTest.kt
+++ b/src/test/kotlin/config/ConfigLoaderTest.kt
@@ -3,6 +3,8 @@ package config
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import utils.TestUtils.DEFAULT_DOCKER_CONTAINER_NAME
+import utils.TestUtils.DEFAULT_DOCKER_PORT
 import utils.TestUtils.getConfigFileFromResources
 
 class ConfigLoaderTest :
@@ -57,5 +59,45 @@ class ConfigLoaderTest :
             config.sourceFilesLocation shouldBe "src/main/kotlin"
             config.sourceFiles shouldBe listOf("File1.kt")
             config.dependencies shouldBe listOf("org.apache.commons:commons-lang3:3.18.0")
+        }
+
+        "should use jarRunConfig if provided" {
+            val configFile = getConfigFileFromResources("test-config-with-jar-run-config.yaml")
+            val configLoader = ConfigLoader()
+
+            val config = configLoader.loadConfig(configFile.absolutePath)
+
+            config.jarRunConfig.dockerContainerName shouldBe "my-test-container"
+            config.jarRunConfig.dockerPort shouldBe 9090
+        }
+
+        "should default jarRunConfig.dockerPort if not provided" {
+            val configFile = getConfigFileFromResources("test-config-with-jar-run-config-no-port.yaml")
+            val configLoader = ConfigLoader()
+
+            val config = configLoader.loadConfig(configFile.absolutePath)
+
+            config.jarRunConfig.dockerContainerName shouldBe "my-test-container"
+            config.jarRunConfig.dockerPort shouldBe DEFAULT_DOCKER_PORT
+        }
+
+        "should default jarRunConfig.dockerContainerName if not provided" {
+            val configFile = getConfigFileFromResources("test-config-with-jar-run-config-no-container-name.yaml")
+            val configLoader = ConfigLoader()
+
+            val config = configLoader.loadConfig(configFile.absolutePath)
+
+            config.jarRunConfig.dockerContainerName shouldBe DEFAULT_DOCKER_CONTAINER_NAME
+            config.jarRunConfig.dockerPort shouldBe 9090
+        }
+
+        "should default whole JarRunConfig if not provided" {
+            val configFile = getConfigFileFromResources("test-config.yaml")
+            val configLoader = ConfigLoader()
+
+            val config = configLoader.loadConfig(configFile.absolutePath)
+
+            config.jarRunConfig.dockerContainerName shouldBe DEFAULT_DOCKER_CONTAINER_NAME
+            config.jarRunConfig.dockerPort shouldBe DEFAULT_DOCKER_PORT
         }
     })

--- a/src/test/kotlin/utils/TestUtils.kt
+++ b/src/test/kotlin/utils/TestUtils.kt
@@ -3,6 +3,9 @@ package utils
 import java.nio.file.Paths
 
 object TestUtils {
+    const val DEFAULT_DOCKER_PORT: Int = 8080
+    const val DEFAULT_DOCKER_CONTAINER_NAME: String = "wiremock-docker-easy-extensions"
+
     fun getConfigFileFromResources(fileName: String) =
         javaClass.classLoader
             .getResource(fileName)

--- a/src/test/resources/test-config-with-jar-run-config-no-container-name.yaml
+++ b/src/test/resources/test-config-with-jar-run-config-no-container-name.yaml
@@ -1,0 +1,10 @@
+source-files-location: src/main/kotlin
+
+source-files:
+  - File1.kt
+
+dependencies:
+
+jar-run-config:
+  docker-port: 9090
+

--- a/src/test/resources/test-config-with-jar-run-config-no-port.yaml
+++ b/src/test/resources/test-config-with-jar-run-config-no-port.yaml
@@ -1,0 +1,10 @@
+source-files-location: src/main/kotlin
+
+source-files:
+  - File1.kt
+
+dependencies:
+
+jar-run-config:
+  docker-container-name: "my-test-container"
+

--- a/src/test/resources/test-config-with-jar-run-config.yaml
+++ b/src/test/resources/test-config-with-jar-run-config.yaml
@@ -1,0 +1,11 @@
+source-files-location: src/main/kotlin
+
+source-files:
+  - File1.kt
+
+dependencies:
+
+jar-run-config:
+  docker-container-name: "my-test-container"
+  docker-port: 9090
+


### PR DESCRIPTION
## Description

Allow configuration of container config via cli `run` command.
configs exposed:
- docker-port
- docker-container-name

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests

