### PR TITLE
move downloaded gradle dist from first to second Docker stage to avoid re-download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN ./gradlew build --no-daemon
 FROM wiremock/wiremock:3.13.1
 COPY --from=wiremock-docker-easy-extensions_builder /builder/build/libs/wiremock-docker-easy-extensions.jar .
 COPY --from=wiremock-docker-easy-extensions_builder /builder/entrypoint.sh /entrypoint.sh
+COPY --from=wiremock-docker-easy-extensions_builder /root/.gradle /root/.gradle
 
 RUN apt-get update && \
     apt-get install -y openjdk-11-jdk && \


### PR DESCRIPTION
## Description

Adds a step into Docker to move the already downloaded gradle dist into the second (last) stage of the image

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests

