### PR TITLE
allow wiremock cl commands to be passed when using JAR

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ jar-run-config:
   docker-container-name: wiremock-docker-easy-extensions
   # (Optional) The port that Docker will expose for WireMock. Defaults to `8080`.
   docker-port: 8080
+  # (Optional - can be empty) List of WireMock CL Commands (need to be valid WireMock CL Commands). Defaults to an empty list.
+  wiremock-cl-options:
+    - --verbose
+    - --record-mappings
 ```
 
 ### Extension Language and Compatibility

--- a/examples/wiremock-docker-easy-extensions-config.yaml
+++ b/examples/wiremock-docker-easy-extensions-config.yaml
@@ -1,4 +1,4 @@
-source-files-location: "extensions"
+source-files-location: extensions
 
 source-files:
   - wdee.examples.ResponseTransformerExtensionNoDependenciesJava.java
@@ -11,3 +11,5 @@ dependencies:
 jar-run-config:
   docker-port: 8080
   docker-container-name: wiremock-docker-easy-extensions
+  wiremock-cl-options:
+    - --verbose

--- a/src/main/kotlin/wdee/config/Config.kt
+++ b/src/main/kotlin/wdee/config/Config.kt
@@ -15,4 +15,5 @@ data class Config(
 data class JarRunConfig(
     @SerialName("docker-container-name") val dockerContainerName: String = "wiremock-docker-easy-extensions",
     @SerialName("docker-port")val dockerPort: Int = 8080,
+    @SerialName("wiremock-cl-options") val wiremockClOptions: List<String>? = emptyList(),
 )

--- a/src/main/kotlin/wdee/config/ContextHolder.kt
+++ b/src/main/kotlin/wdee/config/ContextHolder.kt
@@ -31,6 +31,8 @@ object ContextHolder {
             private set
         lateinit var dockerPort: String
             private set
+        lateinit var wiremockClOptions: List<String>
+            private set
         lateinit var wiremockMappingsPath: String
             private set
         lateinit var wiremockFilesPath: String
@@ -39,6 +41,7 @@ object ContextHolder {
         internal fun init(config: Config) {
             dockerContainerName = config.jarRunConfig.dockerContainerName
             dockerPort = config.jarRunConfig.dockerPort.toString()
+            wiremockClOptions = config.jarRunConfig.wiremockClOptions ?: emptyList()
             wiremockMappingsPath = "$configDir/mappings"
             wiremockFilesPath = "$configDir/__files"
         }

--- a/src/main/kotlin/wdee/docker/DockerRunner.kt
+++ b/src/main/kotlin/wdee/docker/DockerRunner.kt
@@ -34,8 +34,7 @@ class DockerRunner {
                 "-v",
                 "$extensionsJarPath:/var/wiremock/extensions/",
                 "wiremock/wiremock:3.13.1",
-                "--verbose",
-            )
+            ) + ContextHolder.JarRunConfig.wiremockClOptions
 
         Runtime.getRuntime().addShutdownHook(
             Thread {

--- a/src/test/kotlin/utils/TestUtils.kt
+++ b/src/test/kotlin/utils/TestUtils.kt
@@ -5,6 +5,7 @@ import java.nio.file.Paths
 object TestUtils {
     const val DEFAULT_DOCKER_PORT: String = "8080"
     const val DEFAULT_DOCKER_CONTAINER_NAME: String = "wiremock-docker-easy-extensions"
+    val DEFAULT_WIREMOCK_CL_OPTIONS: List<String> = emptyList()
 
     fun getConfigFileFromResources(fileName: String) =
         javaClass.classLoader

--- a/src/test/kotlin/wdee/config/ConfigLoaderTest.kt
+++ b/src/test/kotlin/wdee/config/ConfigLoaderTest.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldEndWith
 import utils.TestUtils.DEFAULT_DOCKER_CONTAINER_NAME
 import utils.TestUtils.DEFAULT_DOCKER_PORT
+import utils.TestUtils.DEFAULT_WIREMOCK_CL_OPTIONS
 import utils.TestUtils.getConfigFileFromResources
 import java.io.File
 
@@ -22,8 +23,9 @@ class ConfigLoaderTest :
             ContextHolder.SourceFilesConfig.sourceFilesLocation shouldEndWith "src/main/kotlin"
             ContextHolder.SourceFilesConfig.sourceFiles shouldBe listOf("File1.kt", "File2.java")
             ContextHolder.SourceFilesConfig.dependencies shouldBe listOf("org.apache.commons:commons-lang3:3.18.0")
-            ContextHolder.JarRunConfig.dockerContainerName shouldBe "wiremock-docker-easy-extensions"
-            ContextHolder.JarRunConfig.dockerPort shouldBe "8080"
+            ContextHolder.JarRunConfig.dockerContainerName shouldBe DEFAULT_DOCKER_CONTAINER_NAME
+            ContextHolder.JarRunConfig.dockerPort shouldBe DEFAULT_DOCKER_PORT
+            ContextHolder.JarRunConfig.wiremockClOptions shouldBe DEFAULT_WIREMOCK_CL_OPTIONS
             ContextHolder.JarRunConfig.wiremockMappingsPath shouldEndWith "mappings"
             ContextHolder.JarRunConfig.wiremockFilesPath shouldEndWith "__files"
         }
@@ -76,6 +78,7 @@ class ConfigLoaderTest :
 
             ContextHolder.JarRunConfig.dockerContainerName shouldBe "my-test-container"
             ContextHolder.JarRunConfig.dockerPort shouldBe "9090"
+            ContextHolder.JarRunConfig.wiremockClOptions shouldBe listOf("--verbose", "--record-mappings")
         }
 
         "should default jarRunConfig.dockerPort if not provided" {
@@ -86,6 +89,7 @@ class ConfigLoaderTest :
 
             ContextHolder.JarRunConfig.dockerContainerName shouldBe "my-test-container"
             ContextHolder.JarRunConfig.dockerPort shouldBe DEFAULT_DOCKER_PORT
+            ContextHolder.JarRunConfig.wiremockClOptions shouldBe listOf("--verbose", "--record-mappings")
         }
 
         "should default jarRunConfig.dockerContainerName if not provided" {
@@ -96,6 +100,25 @@ class ConfigLoaderTest :
 
             ContextHolder.JarRunConfig.dockerContainerName shouldBe DEFAULT_DOCKER_CONTAINER_NAME
             ContextHolder.JarRunConfig.dockerPort shouldBe "9090"
+            ContextHolder.JarRunConfig.wiremockClOptions shouldBe listOf("--verbose", "--record-mappings")
+        }
+
+        "should default jarRunConfig.wiremockClOptions if null in config" {
+            val configFile = getConfigFileFromResources("test-config-with-jar-run-config-null-wiremock-cl-options.yaml")
+            val configReader = ConfigReader()
+
+            configReader.readConfigAndInitializeContext(configFile.absolutePath)
+
+            ContextHolder.JarRunConfig.wiremockClOptions shouldBe emptyList()
+        }
+
+        "should default jarRunConfig.wiremockClOptions if empty in config" {
+            val configFile = getConfigFileFromResources("test-config-with-jar-run-config-empty-wiremock-cl-options.yaml")
+            val configReader = ConfigReader()
+
+            configReader.readConfigAndInitializeContext(configFile.absolutePath)
+
+            ContextHolder.JarRunConfig.wiremockClOptions shouldBe emptyList()
         }
 
         "should default whole JarRunConfig if not provided" {
@@ -106,5 +129,6 @@ class ConfigLoaderTest :
 
             ContextHolder.JarRunConfig.dockerContainerName shouldBe DEFAULT_DOCKER_CONTAINER_NAME
             ContextHolder.JarRunConfig.dockerPort shouldBe DEFAULT_DOCKER_PORT
+            ContextHolder.JarRunConfig.wiremockClOptions shouldBe DEFAULT_WIREMOCK_CL_OPTIONS
         }
     })

--- a/src/test/resources/test-config-with-jar-run-config-empty-wiremock-cl-options.yaml
+++ b/src/test/resources/test-config-with-jar-run-config-empty-wiremock-cl-options.yaml
@@ -7,7 +7,6 @@ dependencies:
 
 jar-run-config:
   docker-container-name: "my-test-container"
+  docker-port: 9090
   wiremock-cl-options:
-    - --verbose
-    - --record-mappings
 

--- a/src/test/resources/test-config-with-jar-run-config-no-container-name.yaml
+++ b/src/test/resources/test-config-with-jar-run-config-no-container-name.yaml
@@ -7,4 +7,7 @@ dependencies:
 
 jar-run-config:
   docker-port: 9090
+  wiremock-cl-options:
+    - --verbose
+    - --record-mappings
 

--- a/src/test/resources/test-config-with-jar-run-config-null-wiremock-cl-options.yaml
+++ b/src/test/resources/test-config-with-jar-run-config-null-wiremock-cl-options.yaml
@@ -7,7 +7,5 @@ dependencies:
 
 jar-run-config:
   docker-container-name: "my-test-container"
-  wiremock-cl-options:
-    - --verbose
-    - --record-mappings
+  docker-port: 9090
 

--- a/src/test/resources/test-config-with-jar-run-config.yaml
+++ b/src/test/resources/test-config-with-jar-run-config.yaml
@@ -8,4 +8,7 @@ dependencies:
 jar-run-config:
   docker-container-name: "my-test-container"
   docker-port: 9090
+  wiremock-cl-options:
+    - --verbose
+    - --record-mappings
 


### PR DESCRIPTION
## Description

allow wiremock cl commands to be passed when using JAR

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests

