### PR TITLE
add a stop command before start to ensure that docker can start the c…

### DIFF
--- a/src/main/kotlin/wdee/docker/DockerRunner.kt
+++ b/src/main/kotlin/wdee/docker/DockerRunner.kt
@@ -25,7 +25,14 @@ class DockerRunner(
                 .resolve(ContextHolder.OutputConfig.DIR)
                 .absolutePath
 
-        val command =
+        val stopCommand =
+            listOf(
+                "docker",
+                "stop",
+                ContextHolder.JarRunConfig.dockerContainerName,
+            )
+
+        val startCommand =
             listOf(
                 "docker",
                 "run",
@@ -52,11 +59,7 @@ class DockerRunner(
                 runCatching {
                     processBuilder
                         .command(
-                            listOf(
-                                "docker",
-                                "stop",
-                                ContextHolder.JarRunConfig.dockerContainerName,
-                            ),
+                            stopCommand,
                         ).start()
                         .waitFor()
                 }.onFailure {
@@ -71,7 +74,12 @@ class DockerRunner(
 
         runCatching {
             processBuilder
-                .command(command)
+                .command(stopCommand)
+                .start()
+                .waitFor()
+
+            processBuilder
+                .command(startCommand)
                 .directory(ContextHolder.projectRoot)
                 .inheritIO()
                 .start()


### PR DESCRIPTION
## Description

[add a stop command before start to ensure that docker can start the c…](https://github.com/alfonsoristorato/wiremock-docker-easy-extensions/commit/38cbf57140bdcb3618340651f8c9eb5ed7953629)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [x] Unit Tests
- [ ] Integration Tests
- [ ] Manual Tests

