### PR TITLE
switch tests back to use StringSpec

### DIFF
--- a/src/test/kotlin/wdee/builder/ExtensionBuilderTest.kt
+++ b/src/test/kotlin/wdee/builder/ExtensionBuilderTest.kt
@@ -1,6 +1,6 @@
 package wdee.builder
 
-import io.kotest.core.spec.style.FreeSpec
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
 import io.kotest.engine.spec.tempdir
@@ -11,9 +11,8 @@ import io.mockk.mockk
 import utils.TestUtils
 import java.io.File
 
-// TODO switch back to StringSpec with kotest 6.0.4
 class ExtensionBuilderTest :
-    FreeSpec({
+    StringSpec({
 
         val tempDir = tempdir()
         val gradleProjectGenerator = GradleProjectGenerator()

--- a/src/test/kotlin/wdee/docker/DockerRunnerTest.kt
+++ b/src/test/kotlin/wdee/docker/DockerRunnerTest.kt
@@ -1,7 +1,7 @@
 package wdee.docker
 
 import io.kotest.assertions.throwables.shouldThrowAny
-import io.kotest.core.spec.style.FreeSpec
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.datatest.withData
 import io.kotest.extensions.system.captureStandardOut
 import io.kotest.matchers.shouldBe
@@ -19,9 +19,8 @@ import utils.TestUtils.DEFAULT_DOCKER_CONTAINER_NAME
 import utils.TestUtils.DEFAULT_DOCKER_PORT
 import wdee.config.ContextHolder
 
-// TODO switch back to StringSpec with kotest 6.0.4
 class DockerRunnerTest :
-    FreeSpec({
+    StringSpec({
         val processBuilder = mockk<ProcessBuilder>()
 
         val process = mockk<Process>()

--- a/src/test/kotlin/wdee/handler/CommandHandlerTest.kt
+++ b/src/test/kotlin/wdee/handler/CommandHandlerTest.kt
@@ -1,7 +1,7 @@
 package wdee.handler
 
 import io.kotest.assertions.throwables.shouldThrow
-import io.kotest.core.spec.style.FreeSpec
+import io.kotest.core.spec.style.StringSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
 import io.kotest.extensions.system.captureStandardOut
@@ -19,9 +19,8 @@ import wdee.builder.ExtensionBuilder
 import wdee.config.ConfigReader
 import wdee.docker.DockerRunner
 
-// TODO switch back to StringSpec with kotest 6.0.4
 class CommandHandlerTest :
-    FreeSpec({
+    StringSpec({
         val configReader = mockk<ConfigReader>()
         val extensionBuilder = mockk<ExtensionBuilder>()
         val dockerRunner = mockk<DockerRunner>()


### PR DESCRIPTION
## Description

[switch tests back to use StringSpec](https://github.com/alfonsoristorato/wiremock-docker-easy-extensions/commit/ec6ca5160261d5468968f1cfd817aa3d1db98612)

## How Has This Been Tested?

- [x] Unit Tests
- [x] Integration Tests
- [ ] Manual Tests

