### PR TITLE
revert shadowJar to 9.2.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,7 +8,7 @@ kotlin                          = "2.3.0"
 kotlinx-serialization-json      = "1.9.0"
 kover                           = "0.9.4"
 mockk                           = "1.14.7"
-shadow-jar                      = "9.3.0"
+shadow-jar                      = "9.2.2"
 testcontainers                  = "2.0.3"
 # Gradle generator
 wiremock                        = "3.13.2"


### PR DESCRIPTION
---
name: Pull Request
about: Propose a change to the project
title: ''
labels: ''
assignees: ''

---

## Description

[revert shadowJar to 9.2.2](https://github.com/alfonsoristorato/wiremock-docker-easy-extensions/commit/ea951155f0ae033e5358b2803eb59ce57947a7a8)
